### PR TITLE
Adding a dry run flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ $ ./kube-ecr-cleanup-controller -h
 Usage of ./kube-ecr-cleanup-controller:
   -alsologtostderr
     	log to standard error as well as files
+  -dry-run
+    	Just log, don't delete any images. (default true)
   -interval int
     	Check interval in minutes. (default 30)
   -kubeconfig string
@@ -89,6 +91,20 @@ Usage of ./kube-ecr-cleanup-controller:
   -vmodule value
     	comma-separated list of pattern=N settings for file-filtered logging
 ```
+
+## Build Locally
+
+Assuming you have your Go environment already configured:
+
+    1. Clone this repository in `$GOPATH/src/github.com/danielfm/kube-ecr-cleanup-controller`
+
+    2. Run `glide i --strip-vendor` and then `make` to build the binary (or `make image` to build the docker image)
+
+    3. Then, just re-tag the image to `<your-name>/kube-ecr-cleanup-controller:<tag>` and push to your own registry, if you feel like it
+
+
+Or, you can use a pre-built image hosted in Docker Hub:
+https://hub.docker.com/r/danielfm/kube-ecr-cleanup-controller/o
 
 ## Donate
 

--- a/cmd/kube-ecr-cleanup-controller/main.go
+++ b/cmd/kube-ecr-cleanup-controller/main.go
@@ -32,6 +32,7 @@ func init() {
 	flag.IntVar(&task.MaxImages, "max-images", task.MaxImages, "Maximum number of images to keep in each repository.")
 	flag.StringVar(&reposStr, "repos", reposStr, "Comma-separated list of repository names to watch.")
 	flag.StringVar(&task.AwsRegion, "region", task.AwsRegion, "AWS Region to use when talking to AWS.")
+	flag.BoolVar(&task.DryRun, "dry-run", task.DryRun, "Just log, don't delete any images.")
 
 	flag.Parse()
 

--- a/pkg/core/task.go
+++ b/pkg/core/task.go
@@ -22,12 +22,16 @@ type CleanupTask struct {
 
 	// Images used by pods running in these namespaces will not get deleted.
 	KubeNamespaces []*string
+
+	DryRun bool
 }
 
+// NewCleanupTask creates a CleanupTask with default values.
 func NewCleanupTask() *CleanupTask {
 	return &CleanupTask{
 		Interval:  30,
 		MaxImages: 900,
 		AwsRegion: "us-east-1",
+		DryRun:    false,
 	}
 }


### PR DESCRIPTION
The --dry-run flag prevents images from being deleted.  Allows for
easy testing of the controller.

Also added a note to README about the build commands.  Fixes #2