### PR TITLE
Adding the ability to cleanup ECR repo in a different account.

### DIFF
--- a/cmd/kube-ecr-cleanup-controller/main.go
+++ b/cmd/kube-ecr-cleanup-controller/main.go
@@ -22,7 +22,7 @@ var task *core.CleanupTask
 var VERSION = "UNKNOWN"
 
 func init() {
-	namespacesStr, reposStr := "default", ""
+	namespacesStr, reposStr, registryID := "default", "", ""
 
 	task = core.NewCleanupTask()
 
@@ -33,6 +33,7 @@ func init() {
 	flag.StringVar(&reposStr, "repos", reposStr, "comma-separated list of repository names to watch.")
 	flag.StringVar(&task.AwsRegion, "region", task.AwsRegion, "AWS Region to use when talking to AWS.")
 	flag.BoolVar(&task.DryRun, "dry-run", task.DryRun, "just log, don't delete any images.")
+	flag.StringVar(&registryID, "registry-id", registryID, "specify a registry account ID. If not specified, uses the account ID of the credentials passed.")
 
 	flag.Parse()
 
@@ -51,6 +52,12 @@ func init() {
 	}
 	if len(repositories) == 0 {
 		glog.Fatalf("Must specify at least one repository to watch, exiting.")
+	}
+
+	if len(registryID) == 0 {
+		task.RegistryID = nil
+	} else {
+		task.RegistryID = &registryID
 	}
 
 	task.KubeNamespaces = namespaces

--- a/pkg/core/task.go
+++ b/pkg/core/task.go
@@ -24,6 +24,8 @@ type CleanupTask struct {
 	KubeNamespaces []*string
 
 	DryRun bool
+
+	RegistryID *string
 }
 
 // NewCleanupTask creates a CleanupTask with default values.

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -53,7 +53,7 @@ func RemoveOldImages(t *core.CleanupTask, kubeClient kubernetes.KubernetesClient
 	}
 	glog.Infof("There are currently %d running pods.", len(pods))
 
-	repos, err := ecrClient.ListRepositories(t.EcrRepositories)
+	repos, err := ecrClient.ListRepositories(t.EcrRepositories, t.RegistryID)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("Cannot list ECR repositories: %v", err))
 		return errors
@@ -66,7 +66,7 @@ func RemoveOldImages(t *core.CleanupTask, kubeClient kubernetes.KubernetesClient
 		repoName := *repo.RepositoryName
 		glog.Infof("Processing '%s' ECR repo.", repoName)
 
-		images, err := ecrClient.ListImages(&repoName)
+		images, err := ecrClient.ListImages(&repoName, t.RegistryID)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("Cannot list images from repo '%s': %v", repoName, err))
 			continue

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -56,7 +56,7 @@ func (m *mockKubeClient) ListAllPods(namespace []*string) ([]*apiv1.Pod, error) 
 	return m.listAllPodsResult, m.listAllPodsError
 }
 
-func (m *mockECRClient) ListRepositories(repositoryNames []*string) ([]*ecr.Repository, error) {
+func (m *mockECRClient) ListRepositories(repositoryNames []*string, registryID *string) ([]*ecr.Repository, error) {
 	if len(repositoryNames) != len(m.expectedRepositoryNames) {
 		m.t.Errorf("Expected repository names to contain %d elements, but it contains %d", len(m.expectedRepositoryNames), len(repositoryNames))
 	}
@@ -70,7 +70,7 @@ func (m *mockECRClient) ListRepositories(repositoryNames []*string) ([]*ecr.Repo
 	return m.listRepositoriesResult, m.listRepositoriesError
 }
 
-func (m *mockECRClient) ListImages(repositoryName *string) ([]*ecr.ImageDetail, error) {
+func (m *mockECRClient) ListImages(repositoryName *string, registryID *string) ([]*ecr.ImageDetail, error) {
 	if m.expectedImagesRepositoryName != *repositoryName {
 		m.t.Errorf("Expected repository name to be %v, but was %v", m.expectedImagesRepositoryName, *repositoryName)
 	}


### PR DESCRIPTION
If passed, the flag -registry-id will set the RegistryID in the
ecr client.  Otherwise it is left nil and the client resumes
its old behavior.  This should be backward-compatible