### PR TITLE
Correctly detect ECR images with a namespace

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -76,7 +76,7 @@ func ECRImagesFromPods(pods []*apiv1.Pod) map[string][]string {
 	encountered := map[string]bool{}
 
 	// Only matches tagged images hosted on ECR
-	re := regexp.MustCompile(`^.*\.dkr\.ecr\.[^\.]+\.amazonaws\.com/([^:/]+):(.*)$`)
+	re := regexp.MustCompile(`^.*\.dkr\.ecr\.[^\.]+\.amazonaws\.com/([^:]+):(.*)$`)
 
 	for _, pod := range pods {
 		podContainers := append(pod.Spec.InitContainers, pod.Spec.Containers...)

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -86,6 +86,24 @@ func TestECRImagesFromPods(t *testing.T) {
 			},
 		},
 
+		// Works for ECR image with a namespace
+		{
+			pods: []*apiv1.Pod{
+				{
+					Spec: apiv1.PodSpec{
+						Containers: []apiv1.Container{
+							{
+								Image: "id.dkr.ecr.region.amazonaws.com/namespace/repo-1:tag-2",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string][]string{
+				"namespace/repo-1": []string{"tag-2"},
+			},
+		},
+
 		// Ignore non-ECR image
 		{
 			pods: []*apiv1.Pod{


### PR DESCRIPTION
When image URI contains a namespace, e.g.

123456789010.dkr.ecr.eu-west-1.amazonaws.com/namespace/image:master

namespace should also be included in a repository name, so that in-use
images are not accidently removed.