### PR TITLE
Add AWS web identity credentials to the provider chain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM centurylink/ca-certs
-MAINTAINER Daniel Martins <daniel.martins@descomplica.com.br>
+LABEL org.opencontainers.image.authors="Daniel Martins <daniel.martins@descomplica.com.br>"
 
 COPY ./bin/kube-ecr-cleanup-controller /kube-ecr-cleanup-controller
 ENTRYPOINT ["/kube-ecr-cleanup-controller"]

--- a/pkg/aws/ecr.go
+++ b/pkg/aws/ecr.go
@@ -63,8 +63,8 @@ func NewECRClient(region string) *ECRClientImpl {
 	creds := credentials.NewChainCredentials(
 		[]credentials.Provider{
 			&credentials.EnvProvider{},
-			&credentials.SharedCredentialsProvider{},
 			&stscreds.WebIdentityRoleProvider{},
+			&credentials.SharedCredentialsProvider{},
 			&ec2rolecreds.EC2RoleProvider{
 				Client: ec2metadata.New(sess),
 			},

--- a/pkg/aws/ecr.go
+++ b/pkg/aws/ecr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
@@ -55,10 +56,13 @@ func NewECRClient(region string) *ECRClientImpl {
 	awsConfig := aws.NewConfig()
 	awsConfig.WithRegion(region)
 
-	sess := session.New(awsConfig)
+	sess := session.Must(
+		session.NewSession(awsConfig),
+	)
 
 	creds := credentials.NewChainCredentials(
 		[]credentials.Provider{
+			&stscreds.WebIdentityRoleProvider{},
 			&credentials.EnvProvider{},
 			&credentials.SharedCredentialsProvider{},
 			&ec2rolecreds.EC2RoleProvider{

--- a/pkg/aws/ecr.go
+++ b/pkg/aws/ecr.go
@@ -62,9 +62,9 @@ func NewECRClient(region string) *ECRClientImpl {
 
 	creds := credentials.NewChainCredentials(
 		[]credentials.Provider{
-			&stscreds.WebIdentityRoleProvider{},
 			&credentials.EnvProvider{},
 			&credentials.SharedCredentialsProvider{},
+			&stscreds.WebIdentityRoleProvider{},
 			&ec2rolecreds.EC2RoleProvider{
 				Client: ec2metadata.New(sess),
 			},


### PR DESCRIPTION
👋 

adds web identity credentials to the provider chain. web identity credentials are the preferred mechanism for EKS [1]. i added them into the chain in the order that the default credential chain places them [2].

builds and tests pass

[1] https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html

[2] https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials